### PR TITLE
Correct URL for /login and remove "aiohttp" text from login page.

### DIFF
--- a/aiohttp_admin/templates/admin.html
+++ b/aiohttp_admin/templates/admin.html
@@ -11,11 +11,11 @@
         <script type="text/javascript">
         var data = window.localStorage.getItem('aiohttp_admin_token');
         if (!data) {
-            window.location.href = "./admin/login";
+            window.location.href = "{{ url('admin.login') }}";
         }
         function logout() {
             window.localStorage.removeItem('aiohttp_admin_token');
-            window.location.href = "./admin/login";
+            window.location.href = "{{ url('admin.login') }}";
         }
         </script>
         {% block body %}

--- a/aiohttp_admin/templates/admin.html
+++ b/aiohttp_admin/templates/admin.html
@@ -3,7 +3,7 @@
     <head>
         {% block head %}
         <meta charset="utf-8">
-        <title>aiohttp Admin</title>
+        <title>{{ name }} Admin</title>
         <link rel="stylesheet" href="{{ url('admin.static', filename='ng-admin/ng-admin.min.css') }}">
         {% endblock %}
     </head>

--- a/aiohttp_admin/templates/login.html
+++ b/aiohttp_admin/templates/login.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>aiohttp admin</title>
+    <title>Admin Login</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="{{ url('admin.static', filename='css/login.css') }}" rel="stylesheet">


### PR DESCRIPTION
Use correct URL for /login and remove "aiohttp" text from login page.