### PR TITLE
Remove config.js from /login so can be protected

### DIFF
--- a/aiohttp_admin/templates/login.html
+++ b/aiohttp_admin/templates/login.html
@@ -7,7 +7,6 @@
     <link href="{{ url('admin.static', filename='css/login.css') }}" rel="stylesheet">
     <link href="{{ url('admin.static', filename='ng-admin/ng-admin.min.css') }}" rel="prefetch">
     <link href="{{ url('admin.static', filename='ng-admin/ng-admin.min.js') }}" rel="prefetch">
-    <link href="{{ url('admin.config', filename='config.js') }}" rel="prefetch">
 </head>
 <body>
     <div id="login-panel">


### PR DESCRIPTION
I'm planning to put `config.js` behind `@protected`, so first step is not to prefetch and blab it before login.