### PR TITLE
Use HMAC to secure identity token we give out

### DIFF
--- a/aiohttp_admin/security.py
+++ b/aiohttp_admin/security.py
@@ -71,16 +71,40 @@ class DummyAuthPolicy(AdminAbstractAuthorizationPolicy):
 
 class DummyTokenIdentityPolicy(AbstractIdentityPolicy):
 
+    def __init__(self, server_secret=None):
+        '''
+            Makes identity tokens using HMAC(SHA-512) over a server-side secret.
+
+            Provide a secret (20+ bytes) or we'll pick one at runtime.
+        '''
+        from hmac import HMAC
+        from hashlib import sha512
+        import os
+
+        if server_secret is None:
+            server_secret = os.urandom(32)
+
+        self.hmac = HMAC(server_secret, digestmod=sha512)
+
+    def _make_hmac(self, ident):
+        hm = self.hmac.copy()
+        hm.update(ident.encode('utf8'))
+        return hm.hexdigest()
+
     async def identify(self, request):
         # validate token
-        identity = request.headers.get("Authorization")
+        hdr = request.headers.get("Authorization")
+        identity, check = hdr.rsplit(':', 1)
+        if check != self._make_hmac(identity):
+            return None
         return identity
 
     async def remember(self, request, response, identity, **kwargs):
         # save token in storage and reply to client
-        response.headers['X-Token'] = identity
+        response.headers['X-Token'] = identity + ':' + self._make_hmac(identity)
 
     async def forget(self, request, response):
         token = request.headers.get("Authorization")
-        # destroy token,  remove it from storage
         assert token
+        assert ':' in token
+        # no real way to force client side to forget

--- a/aiohttp_admin/security.py
+++ b/aiohttp_admin/security.py
@@ -96,6 +96,8 @@ class DummyTokenIdentityPolicy(AbstractIdentityPolicy):
     async def identify(self, request):
         # validate token
         hdr = request.headers.get("Authorization")
+        if not hdr or ':' not in hdr:
+            return None
         identity, check = hdr.rsplit(':', 1)
         if check != self._make_hmac(identity):
             return None

--- a/aiohttp_admin/security.py
+++ b/aiohttp_admin/security.py
@@ -73,9 +73,11 @@ class DummyTokenIdentityPolicy(AbstractIdentityPolicy):
 
     def __init__(self, server_secret=None):
         '''
-            Makes identity tokens using HMAC(SHA-512) over a server-side secret.
+            Makes identity tokens using HMAC(SHA-512) over a
+            server-side secret.
 
-            Provide a secret (20+ bytes) or we'll pick one at runtime.
+            Provide a secret (20+ bytes) or we'll pick one
+            at runtime.
         '''
         from hmac import HMAC
         from hashlib import sha512
@@ -101,7 +103,7 @@ class DummyTokenIdentityPolicy(AbstractIdentityPolicy):
 
     async def remember(self, request, response, identity, **kwargs):
         # save token in storage and reply to client
-        response.headers['X-Token'] = identity + ':' + self._make_hmac(identity)
+        response.headers['X-Token'] = identity+':'+self._make_hmac(identity)
 
     async def forget(self, request, response):
         token = request.headers.get("Authorization")

--- a/aiohttp_admin/security.py
+++ b/aiohttp_admin/security.py
@@ -1,6 +1,10 @@
 from abc import abstractmethod
 from enum import Enum
 
+from hmac import HMAC
+from hashlib import sha512
+import os
+
 from aiohttp_security import AbstractAuthorizationPolicy
 from aiohttp_security import AbstractIdentityPolicy
 from aiohttp_security import permits
@@ -79,9 +83,6 @@ class DummyTokenIdentityPolicy(AbstractIdentityPolicy):
             Provide a secret (20+ bytes) or we'll pick one
             at runtime.
         '''
-        from hmac import HMAC
-        from hashlib import sha512
-        import os
 
         if server_secret is None:
             server_secret = os.urandom(32)


### PR DESCRIPTION
Beef up the identity token with HMAC over a server-side secret.

I'm having second thoughts about this PR, but submitting for your consideration anyway.

- random server key will create problems when server code auto-reloads (but user should set it to some config value anyway)
- should probably just use one of the identity classes from `aiohttp_security` instead