### PR TITLE
Upgraded docker-py package to v2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,8 @@ aiohttp==2.3.6
 aiomysql==0.0.9
 aiopg==0.13.1
 coverage==4.4.2
+docker==2.6.1
 docker-compose==1.17.1
-docker-py==1.10.6
 flake8==3.5.0
 ipdb==0.10.3
 motor==1.1

--- a/tests/docker_fixtures.py
+++ b/tests/docker_fixtures.py
@@ -7,8 +7,8 @@ import pymongo
 import pymysql
 import pytest
 
-from docker import Client as DockerClient
-
+from docker import APIClient
+from docker import from_env
 
 TEMP_FOLDER = Path('/tmp') / 'aiohttp_admin'
 
@@ -37,9 +37,9 @@ def host():
 @pytest.fixture(scope='session')
 def docker():
     if os.environ.get('DOCKER_MACHINE_IP') is not None:
-        docker = DockerClient.from_env(assert_hostname=False)
+        docker = from_env(assert_hostname=False)
     else:
-        docker = DockerClient(version='auto')
+        docker = APIClient(version='auto')
     return docker
 
 


### PR DESCRIPTION
I've upgraded `docker-py` package from 1.10.6 to 2.6.1.

Motivation: `docker-py` 2.0.0 has introduced [breaking changes](http://docker-py.readthedocs.io/en/stable/change-log.html#breaking-changes). Here are some of them:
* pip package renamed from `docker-py` to `docker`
* docker.Client has been renamed to docker.APIClient
* docker.from_env now creates a DockerClient instance instead of an APIClientinstance

Tested it locally, with simple docker (not docker-machine) version 17.09.1-ce.

If we need some kind of back-compatibility (which I hope we don't :) ) - we should probably specify the version of required `docker` and `docker-compose` system components for `aiohttp_admin` version prior this PR. And keep them synced with packages versions from `requirements.txt`.

And even now we should probably put current versions for `docker` and `docker-compose` system components  in documentation.